### PR TITLE
WIP: Group heirarchy

### DIFF
--- a/groups.cabal
+++ b/groups.cabal
@@ -1,7 +1,7 @@
 name:                groups
 version:             0.4.1.0
 synopsis:            Haskell 98 groups
-description:         
+description:
   Haskell 98 groups. A group is a monoid with invertibility.
 license:             BSD3
 license-file:        LICENSE
@@ -14,6 +14,6 @@ cabal-version:       >=1.8
 
 library
   exposed-modules:     Data.Group
-  -- other-modules:       
+  -- other-modules:
   build-depends:       base <5
   hs-source-dirs:      src

--- a/src/Data/Group.hs
+++ b/src/Data/Group.hs
@@ -77,7 +77,9 @@ instance (Group a, Group b, Group c, Group d, Group e) => Group (a, b, c, d, e) 
 
 -- |An 'Abelian' group is a 'Group' that follows the rule:
 --
--- @a \<> b == b \<> a@
+-- @
+-- a \<> b == b \<> a
+-- @
 class Group g => Abelian g
 
 instance Abelian ()
@@ -98,9 +100,12 @@ instance (Abelian a, Abelian b, Abelian c, Abelian d) => Abelian (a, b, c, d)
 
 instance (Abelian a, Abelian b, Abelian c, Abelian d, Abelian e) => Abelian (a, b, c, d, e)
 
--- | A 'Group' G is 'Cyclic' if there exists an element x of G such that for all y in G, there exists an n, such that
+-- | A 'Group' G is 'Cyclic' if there exists an element x of G such
+-- that for all y in G, there exists an n, such that:
 --
--- @y = pow x n@
+-- @
+-- y = pow x n
+-- @
 class Group a => Cyclic a where
   generator :: a
 

--- a/src/Data/Group.hs
+++ b/src/Data/Group.hs
@@ -20,7 +20,7 @@ import Data.Monoid
 -- 'inv' x \<>     x \<> 'inv' x = 'inv' x
 -- @
 class Semigroup g => RegularSemigroup g where
-  inv :: g -> g
+  invert :: g -> g
 
 -- | An 'InverseSemigroup' is a 'RegularSemigroup' with the additional
 -- restriction that inverses are unique.
@@ -38,9 +38,6 @@ class RegularSemigroup g => InverseSemigroup g
 -- 'inv' a \<>     a == 'mempty'
 -- @
 class (InverseSemigroup g, Monoid g) => Group g where
-  invert :: g -> g
-  invert = inv
-
   -- |@'pow' a n == a \<> a \<> ... \<> a @
   --
   -- @ (n lots of a) @
@@ -63,31 +60,34 @@ class (InverseSemigroup g, Monoid g) => Group g where
 {-# DEPRECATED invert "use inv from RegularSemigroup instead" #-}
 
 instance RegularSemigroup () where
-  inv () = ()
+  invert () = ()
 
 instance Num a => RegularSemigroup (Sum a) where
-  inv = Sum . negate . getSum
+  invert = Sum . negate . getSum
+  {-# INLINE invert #-}
 
 instance Fractional a => RegularSemigroup (Product a) where
-  inv = Product . recip . getProduct
+  invert = Product . recip . getProduct
+  {-# INLINE invert #-}
 
 instance RegularSemigroup a => RegularSemigroup (Dual a) where
-  inv = Dual . inv . getDual
+  invert = Dual . invert . getDual
+  {-# INLINE invert #-}
 
 instance RegularSemigroup b => RegularSemigroup (a -> b) where
-  inv f = inv . f
+  invert f = invert . f
 
 instance (RegularSemigroup a, RegularSemigroup b) => RegularSemigroup (a, b) where
-  inv (a, b) = (inv a, inv b)
+  invert (a, b) = (invert a, invert b)
 
 instance (RegularSemigroup a, RegularSemigroup b, RegularSemigroup c) => RegularSemigroup (a, b, c) where
-  inv (a, b, c) = (inv a, inv b, inv c)
+  invert (a, b, c) = (invert a, invert b, invert c)
 
 instance (RegularSemigroup a, RegularSemigroup b, RegularSemigroup c, RegularSemigroup d) => RegularSemigroup (a, b, c, d) where
-  inv (a, b, c, d) = (inv a, inv b, inv c, inv d)
+  invert (a, b, c, d) = (invert a, invert b, invert c, invert d)
 
 instance (RegularSemigroup a, RegularSemigroup b, RegularSemigroup c, RegularSemigroup d, RegularSemigroup e) => RegularSemigroup (a, b, c, d, e) where
-  inv (a, b, c, d, e) = (inv a, inv b, inv c, inv d, inv e)
+  invert (a, b, c, d, e) = (invert a, invert b, invert c, invert d, invert e)
 
 instance InverseSemigroup ()
 instance Num a => InverseSemigroup (Sum a)
@@ -100,42 +100,30 @@ instance (InverseSemigroup a, InverseSemigroup b, InverseSemigroup c, InverseSem
 instance (InverseSemigroup a, InverseSemigroup b, InverseSemigroup c, InverseSemigroup d, InverseSemigroup e) => InverseSemigroup (a, b, c, d, e)
 
 instance Group () where
-  invert () = ()
   pow () _ = ()
 
 instance Num a => Group (Sum a) where
-  invert = Sum . negate . getSum
-  {-# INLINE invert #-}
   pow (Sum a) b = Sum (a * fromIntegral b)
 
 instance Fractional a => Group (Product a) where
-  invert = Product . recip . getProduct
-  {-# INLINE invert #-}
   pow (Product a) b = Product (a ^^ b)
 
 instance Group a => Group (Dual a) where
-  invert = Dual . invert . getDual
-  {-# INLINE invert #-}
   pow (Dual a) n = Dual (pow a n)
 
 instance Group b => Group (a -> b) where
-  invert f = invert . f
   pow f n e = pow (f e) n
 
 instance (Group a, Group b) => Group (a, b) where
-  invert (a, b) = (invert a, invert b)
   pow (a, b) n = (pow a n, pow b n)
 
 instance (Group a, Group b, Group c) => Group (a, b, c) where
-  invert (a, b, c) = (invert a, invert b, invert c)
   pow (a, b, c) n = (pow a n, pow b n, pow c n)
 
 instance (Group a, Group b, Group c, Group d) => Group (a, b, c, d) where
-  invert (a, b, c, d) = (invert a, invert b, invert c, invert d)
   pow (a, b, c, d) n = (pow a n, pow b n, pow c n, pow d n)
 
 instance (Group a, Group b, Group c, Group d, Group e) => Group (a, b, c, d, e) where
-  invert (a, b, c, d, e) = (invert a, invert b, invert c, invert d, invert e)
   pow (a, b, c, d, e) n = (pow a n, pow b n, pow c n, pow d n, pow e n)
 
 -- |An 'Abelian' group is a 'Group' that follows the rule:

--- a/src/Data/Group.hs
+++ b/src/Data/Group.hs
@@ -2,7 +2,7 @@ module Data.Group where
 
 import Data.Monoid
 
--- |A 'Group' is a 'Monoid' plus a function, 'invert', such that: 
+-- |A 'Group' is a 'Monoid' plus a function, 'invert', such that:
 --
 -- @a \<> invert a == mempty@
 --
@@ -20,7 +20,7 @@ class Monoid m => Group m where
     EQ -> mempty
     GT -> f x0 n0
     where
-      f x n 
+      f x n
         | even n = f (x `mappend` x) (n `quot` 2)
         | n == 1 = x
         | otherwise = g (x `mappend` x) (n `quot` 2) x
@@ -28,7 +28,7 @@ class Monoid m => Group m where
         | even n = g (x `mappend` x) (n `quot` 2) c
         | n == 1 = x `mappend` c
         | otherwise = g (x `mappend` x) (n `quot` 2) (x `mappend` c)
-  
+
 instance Group () where
   invert () = ()
   pow () _ = ()
@@ -37,7 +37,7 @@ instance Num a => Group (Sum a) where
   invert = Sum . negate . getSum
   {-# INLINE invert #-}
   pow (Sum a) b = Sum (a * fromIntegral b)
-  
+
 instance Fractional a => Group (Product a) where
   invert = Product . recip . getProduct
   {-# INLINE invert #-}
@@ -55,7 +55,7 @@ instance Group b => Group (a -> b) where
 instance (Group a, Group b) => Group (a, b) where
   invert (a, b) = (invert a, invert b)
   pow (a, b) n = (pow a n, pow b n)
-  
+
 instance (Group a, Group b, Group c) => Group (a, b, c) where
   invert (a, b, c) = (invert a, invert b, invert c)
   pow (a, b, c) n = (pow a n, pow b n, pow c n)
@@ -69,7 +69,7 @@ instance (Group a, Group b, Group c, Group d, Group e) => Group (a, b, c, d, e) 
   pow (a, b, c, d, e) n = (pow a n, pow b n, pow c n, pow d n, pow e n)
 
 -- |An 'Abelian' group is a 'Group' that follows the rule:
--- 
+--
 -- @a \<> b == b \<> a@
 class Group g => Abelian g
 
@@ -100,4 +100,3 @@ class Group a => Cyclic a where
 generated :: Cyclic a => [a]
 generated =
   iterate (mappend generator) mempty
-

--- a/src/Data/Group.hs
+++ b/src/Data/Group.hs
@@ -1,3 +1,10 @@
+{-|
+Module      : Data.Group
+Copyright   : (C) 2013 Nathan van Doorn
+License     : BSD-3
+Maintainer  : nvd1234@gmail.com
+-}
+
 module Data.Group where
 
 import Data.Monoid


### PR DESCRIPTION
Add `InverseSemigroup` above `Group`, and `RegularSemigroup` above that.

There are a few things that I think need resolving before this gets merged:

1. Is there enough of a use for the superclasses to justify making everyone else write two extra instances to get to `Group`? The main one I was toying with was (borrowing some bits from `semialign`):

```haskell
newtype Pointwise f a = Pointwise (f a)

instance (Semialign f, Semigroup a) => Semigroup (Pointwise f a) where
  (Pointwise fa) <> (Pointwise fb) = salign fa fb

instance (Semialign f, RegularSemigroup a) => RegularSemigroup (Pointwise f a) where
  inv (Pointwise fa) = Pointwise (inv <$> fa)
```

And then using this to compute diffs. But it didn't pay out into anything ergonomic. I probably need to think more about whether this should be done with `Zip` or `Semialign`.

Ed mentioned:

> I'm currently poking at the use of inverse semigroups to better model something like the underlying theory for "nominal renaming sets" and if not if i can use the pattern from nominal sets for other inverse semigroups i happen to be interested in that i'd like to be able to act on sets with.

(Did this pay out?)

2. Should the inverse operation be called `inv`, or something else? (Bikeshedding)

3. If pseudoinverses in `RegularSemigroup` are not unique, should there be a function `invs :: g -> NonEmpty g`, with no guarantee that it returns every pseudoinverse (too expensive to calculate otherwise)?

4. Where should `pow` sit in the hierarchy? If you have unique inverses (`InverseSemigroup`) you can compute sensible `pow` for any nonzero integer power, but zero would have to be `x <> inv x` or `inv x <> x`, and I don't think you have a guarantee that those are the same.