### PR TITLE
Add missing instances for Down and Ap, docs, a terminating 'generated'.

### DIFF
--- a/src/Data/Group.hs
+++ b/src/Data/Group.hs
@@ -99,7 +99,7 @@ instance Group a => Group (Down a) where
 #endif
 
 #if MIN_VERSION_base(4,12,0)
-instance (Applicative f, Abelian a) => Group (Ap f a) where
+instance (Applicative f, Group a) => Group (Ap f a) where
   invert (Ap f) = Ap (invert <$> f)
 #endif
 
@@ -229,4 +229,14 @@ instance Group a => Group (Op a b) where
   pow (Op f) n = Op (\e -> pow (f e) n)
 
 instance Abelian a => Abelian (Op a b)
+#endif
+
+#if MIN_VERSION_base(4,11,0)
+instance Cyclic a => Cyclic (Down a) where
+  generator = Down generator
+#endif
+
+#if MIN_VERSION_base(4,12,0)
+instance (Applicative f, Cyclic a) => Cyclic (Ap f a) where
+  generator = Ap (pure generator)
 #endif

--- a/src/Data/Group.hs
+++ b/src/Data/Group.hs
@@ -98,11 +98,6 @@ instance Group a => Group (Down a) where
   invert (Down a) = Down (invert a)
 #endif
 
-#if MIN_VERSION_base(4,12,0)
-instance (Applicative f, Group a) => Group (Ap f a) where
-  invert (Ap f) = Ap (invert <$> f)
-#endif
-
 -- |An 'Abelian' group is a 'Group' that follows the rule:
 --
 -- @a \<> b == b \<> a@
@@ -129,11 +124,6 @@ instance (Abelian a, Abelian b, Abelian c, Abelian d, Abelian e) => Abelian (a, 
 #if MIN_VERSION_base(4,11,0)
 instance Abelian a => Abelian (Down a)
 #endif
-
-#if MIN_VERSION_base(4,12,0)
-instance (Applicative f, Abelian a) => Abelian (Ap f a)
-#endif
-
 
 -- | A 'Group' G is 'Cyclic' if there exists an element x of G such that for all y in G, there exists an n, such that
 --
@@ -234,9 +224,4 @@ instance Abelian a => Abelian (Op a b)
 #if MIN_VERSION_base(4,11,0)
 instance Cyclic a => Cyclic (Down a) where
   generator = Down generator
-#endif
-
-#if MIN_VERSION_base(4,12,0)
-instance (Applicative f, Cyclic a) => Cyclic (Ap f a) where
-  generator = Ap (pure generator)
 #endif


### PR DESCRIPTION
Hey! 

This PR adds Group, Cyclic, and Abelian instances for `Ap` and `Down`, along with a terminating version of `generated` that still fuses appropriately at the cost of an `Eq` constraint.

If the `generated` function isn't amenable, i can just inline it in `group-theory`. 