### PR TITLE
Use `base-orphans` to make the GHC.Generics instances unconditional

### DIFF
--- a/groups.cabal
+++ b/groups.cabal
@@ -22,7 +22,11 @@ source-repository head
 library
   exposed-modules:     Data.Group
   -- other-modules:
-  build-depends:       base >= 4.6 && < 5
-                     , commutative-semigroups >= 0.0 && < 0.1
   hs-source-dirs:      src
   default-language:    Haskell2010
+
+  build-depends:       base >= 4.6 && < 5
+                     , commutative-semigroups >= 0.0 && < 0.1
+
+  if impl(ghc < 8.6) -- really, if base < 8.12
+    build-depends: base-orphans >= 0.8 && < 0.9

--- a/src/Data/Group.hs
+++ b/src/Data/Group.hs
@@ -171,7 +171,6 @@ instance Cyclic a => Cyclic (Identity a) where
 -- (:*:) and (:.:) exist since base-4.6.0.0 but the Monoid instances
 -- arrive in base-4.12.0.0.
 -- Also, contravariant was moved into base in this version.
-#if MIN_VERSION_base(4,12,0)
 -- | Product of groups, Functor style.
 instance (Group (f a), Group (g a)) => Group ((f :*: g) a) where
   invert (a :*: b) = invert a :*: invert b
@@ -184,6 +183,7 @@ instance Group (f (g a)) => Group ((f :.: g) a) where
   invert (Comp1 xs) = Comp1 (invert xs)
   Comp1 xs ~~ Comp1 ys = Comp1 (xs ~~ ys)
 
+#if MIN_VERSION_base(4,12,0)
 instance Group a => Group (Op a b) where
   invert (Op f) = Op (invert f)
   pow (Op f) n = Op (\e -> pow (f e) n)


### PR DESCRIPTION
Fixes #8
